### PR TITLE
make baseeffect abstract class public

### DIFF
--- a/Spectaculum-Core/src/main/java/net/protyposis/android/spectaculum/effects/BaseEffect.java
+++ b/Spectaculum-Core/src/main/java/net/protyposis/android/spectaculum/effects/BaseEffect.java
@@ -28,7 +28,7 @@ import net.protyposis.android.spectaculum.gles.Texture2D;
  * {@link ShaderEffect}.
  * Created by Mario on 18.07.2014.
  */
-abstract class BaseEffect implements Effect, Parameter.Listener {
+public abstract class BaseEffect implements Effect, Parameter.Listener {
 
     private String mName;
     private List<Parameter> mParameters;


### PR DESCRIPTION
Allow's one to inherit the base effect outside of the spectaculum package.
